### PR TITLE
Fix divide by zero panic when calling Update()

### DIFF
--- a/whisper/whisper.go
+++ b/whisper/whisper.go
@@ -338,11 +338,12 @@ func (w Whisper) Update(point Point) (err error) {
 	// Find the higher-precision archive that covers the timestamp
 	var lowerArchives []ArchiveInfo
 	var currentArchive ArchiveInfo
-	for i, currentArchive := range w.Header.Archives {
+	for i, ca := range w.Header.Archives {
 		if currentArchive.Retention() < diff {
 			continue
 		}
 		lowerArchives = w.Header.Archives[i+1:]
+		currentArchive = ca
 	}
 
 	// Normalize the point's timestamp to the current archive's precision and write the point


### PR DESCRIPTION
Hey there!

I ran into a panic when trying to call `Update()` on a whisper archive:

```
panic: runtime error: integer divide by zero
[signal 0x8 code=0x7 addr=0x86f8d pc=0x86f8d]

goroutine 4 [running]:
github.com/kisielk/whisper-go/whisper.Whisper.Update(0x278d0000000001, 0x13f000000, 0xf840043630, 0x100000001, 0xf84006b1c0, ...)
        /Users/blake/go/src/github.com/kisielk/whisper-go/whisper/whisper.go:349 +0x1af
    pulsedb/whisper.(*Storage).Append(0xf8400433a0, 0xf84006b230, 0xf800000006, 0xf84006b1b8, 0x600000004, ...)
```

It looks like the outer declaration of `currentArchive` never gets used in the for loop due to the `:=` initialization. This means that after the for loop breaks, `currentArchive` will still be 'empty' due to the inner scope collision. I wrote up a little test program to double check this theory:

``` go
package main

import (
    "fmt"
)

func main() {
    numbers := []int{5}
    var n int
    fmt.Printf("Before: %d\n", n)
    for i, n := range numbers {
        fmt.Printf("Loop, i: %d value: %d\n", i, n)
    }

    fmt.Printf("After: %d\n", n)
}
```

Output:

```
Before: 0
Loop, i: 0 value: 5
After: 0
```

This diff got rid of the panic, and allowed the point to be successfully written. Let me know what you think!

Blake
