### PR TITLE
Whisper.Update archive ordering bug fix

### DIFF
--- a/whisper/whisper.go
+++ b/whisper/whisper.go
@@ -348,11 +348,11 @@ func (w Whisper) Update(point Point) error {
 	var lowerArchives []ArchiveInfo
 	var currentArchive ArchiveInfo
 	for i, ca := range w.Header.Archives {
-		if ca.Retention() < diff {
-			continue
+		if ca.Retention() > diff {
+			lowerArchives = w.Header.Archives[i+1:]
+			currentArchive = ca
+			break
 		}
-		lowerArchives = w.Header.Archives[i+1:]
-		currentArchive = ca
 	}
 
 	// Normalize the point's timestamp to the current archive's precision and write the point


### PR DESCRIPTION
My whisper files were being written, but they didn't contain the expected data. Discovered that the loop over the db archives was always falling through to the lowest resolution archive while thinking that it had found the highest resolution archive. Quick tweak and data starts showing up as expected.
