### PR TITLE
Fixes certain instances of database corruption

### DIFF
--- a/whisper/whisper.go
+++ b/whisper/whisper.go
@@ -178,7 +178,7 @@ var precisionRegexp = regexp.MustCompile("^(\\d+)([smhdwy]?)")
 func init() {
 	pointSize = uint32(binary.Size(Point{}))
 	metadataSize = uint32(binary.Size(Metadata{}))
-	archiveSize = uint32(binary.Size(archive{}))
+	archiveSize = uint32(binary.Size(ArchiveInfo{}))
 }
 
 // Read the header of a whisper database


### PR DESCRIPTION
`archiveSize` is used as the size of an `ArchiveInfo` struct, not an `archive` struct, make sure we're getting the size of the right struct type.
