### PR TITLE
Add read-only open support.

### DIFF
--- a/whisper/whisper.go
+++ b/whisper/whisper.go
@@ -371,7 +371,16 @@ func openWhisper(f *os.File) (*Whisper, error) {
 
 // Open opens an existing whisper database
 func Open(path string) (*Whisper, error) {
-	file, err := os.OpenFile(path, os.O_RDWR, 0666)
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	return openWhisper(file)
+}
+
+// OpenFile opens an existing whisper database specifying OS flags and permissions
+func OpenFile(path string, flags int, perm os.FileMode) (*Whisper, error) {
+	file, err := os.OpenFile(path, flags, perm)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Hi,

I added a basic `read-only` open support for Whisper databases files by separating opening functions.

It implements both `Open` and `OpenFile` methods as used in the `os` package. 

Could you please take a look at this pull request and let me know if it suits to you?

Best regards,
## 

Vincent Batoufflet
